### PR TITLE
Add basic Chicken Scheme wrapper for liboqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # scheme-liboqs
+
+This project provides a simple Chicken Scheme wrapper for the
+[liboqs](https://github.com/open-quantum-safe/liboqs) C library.  The wrapper
+allows direct invocation of liboqs functions from Scheme using the native FFI.
+
+## Building liboqs
+
+liboqs is not included in this repository.  Obtain and build the library
+separately, for example:
+
+```bash
+$ git clone https://github.com/open-quantum-safe/liboqs.git
+$ cd liboqs
+$ mkdir build && cd build
+$ cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
+$ ninja
+$ sudo make install    # or copy `lib/liboqs.so` to a reachable location
+```
+
+Ensure `liboqs.so` is in your library search path or set `LD_LIBRARY_PATH`
+accordingly.
+
+## Using the wrapper
+
+Compile the example program with `csc`, passing the library path via `-L` if
+needed:
+
+```bash
+$ csc -I /usr/local/include -L -loqs examples/demo.scm -o demo
+$ LD_LIBRARY_PATH=/usr/local/lib ./demo
+```
+
+The `liboqs` module exposes helpers for creating a KEM object, generating
+keypairs and performing encapsulation/decapsulation.

--- a/examples/demo.scm
+++ b/examples/demo.scm
@@ -1,0 +1,20 @@
+(import scheme (chicken base) (chicken foreign) srfi-4 liboqs)
+
+;; Simple demonstration of generating a keypair, encapsulating,
+;; and decapsulating using the first available algorithm.
+
+(let* ((count (kem-alg-count))
+       (alg-name (kem-alg-identifier 0))
+       (kem (kem-new alg-name)))
+  (unless kem
+    (error "Could not initialize KEM"))
+  (let-values (((status pk sk) (kem-keypair kem)))
+    (unless (zero? status) (error "keypair failed"))
+    (let-values (((status ct ss1) (kem-encap kem pk)))
+      (unless (zero? status) (error "encap failed"))
+      (let-values (((status ss2) (kem-decap kem ct sk)))
+        (unless (zero? status) (error "decap failed"))
+        (print "Algorithm: " alg-name)
+        (print "Shared secrets match: " (equal? ss1 ss2))))
+    (kem-free kem)))
+

--- a/src/liboqs.scm
+++ b/src/liboqs.scm
@@ -1,0 +1,68 @@
+(module liboqs
+  (kem-alg-count kem-alg-identifier kem-new kem-free
+   kem-length-public-key kem-length-secret-key
+   kem-length-ciphertext kem-length-shared-secret
+   kem-keypair kem-encap kem-decap)
+
+  (import scheme (chicken base) (chicken foreign) srfi-4)
+
+  (foreign-declare "#include <oqs/oqs.h>")
+
+
+  (define kem-alg-count
+    (foreign-lambda* int ((void)) "return OQS_KEM_alg_count();"))
+
+  (define kem-alg-identifier
+    (foreign-lambda* c-string ((size_t i)) "return OQS_KEM_alg_identifier(i);"))
+
+  (define kem-new
+    (foreign-lambda* c-pointer ((c-string name)) "return OQS_KEM_new(name);"))
+
+  (define kem-free
+    (foreign-lambda* void ((c-pointer kem)) "OQS_KEM_free(kem);"))
+
+  (define kem-length-public-key
+    (foreign-lambda* size_t ((c-pointer kem))
+      "return ((OQS_KEM*)kem)->length_public_key;"))
+
+  (define kem-length-secret-key
+    (foreign-lambda* size_t ((c-pointer kem))
+      "return ((OQS_KEM*)kem)->length_secret_key;"))
+
+  (define kem-length-ciphertext
+    (foreign-lambda* size_t ((c-pointer kem))
+      "return ((OQS_KEM*)kem)->length_ciphertext;"))
+
+  (define kem-length-shared-secret
+    (foreign-lambda* size_t ((c-pointer kem))
+      "return ((OQS_KEM*)kem)->length_shared_secret;"))
+
+  (define (kem-keypair kem)
+    (let* ((pk-len (kem-length-public-key kem))
+           (sk-len (kem-length-secret-key kem))
+           (pk (make-u8vector pk-len))
+           (sk (make-u8vector sk-len))
+           (status ((foreign-lambda* int ((c-pointer kem) (u8vector pk) (u8vector sk))
+                    "return OQS_KEM_keypair(kem, pk, sk);")
+                    kem pk sk)))
+      (values status pk sk)))
+
+  (define (kem-encap kem pk)
+    (let* ((ct-len (kem-length-ciphertext kem))
+           (ss-len (kem-length-shared-secret kem))
+           (ct (make-u8vector ct-len))
+           (ss (make-u8vector ss-len))
+           (status ((foreign-lambda* int ((c-pointer kem) (u8vector ct) (u8vector ss) (u8vector pk))
+                    "return OQS_KEM_encaps(kem, ct, ss, pk);")
+                    kem ct ss pk)))
+      (values status ct ss)))
+
+  (define (kem-decap kem ct sk)
+    (let* ((ss-len (kem-length-shared-secret kem))
+           (ss (make-u8vector ss-len))
+           (status ((foreign-lambda* int ((c-pointer kem) (u8vector ss) (u8vector ct) (u8vector sk))
+                    "return OQS_KEM_decaps(kem, ss, ct, sk);")
+                    kem ss ct sk)))
+      (values status ss)))
+)
+


### PR DESCRIPTION
## Summary
- write an FFI wrapper module (`src/liboqs.scm`) that exposes common KEM functions from liboqs
- add an example program demonstrating key encapsulation (`examples/demo.scm`)
- document how to build liboqs and compile the example in `README.md`

## Testing
- `csc -I build-liboqs/build/include -L build-liboqs/build/lib -L -loqs examples/demo.scm -o demo` *(fails: cannot import from undefined module liboqs)*

------
https://chatgpt.com/codex/tasks/task_e_68528037b0248322b375e124324e2b13