### PR TITLE
Add liboqs C wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,41 @@ accordingly.
 
 ## Building the Scheme module
 
-Compile the wrapper itself before building the demo.  The command below
-creates the shared object `liboqs.so` and its import library:
+First build the small C wrapper that exposes a simplified API.  Link it
+against `liboqs`:
 
 ```bash
-$ csc -s -j liboqs -I /usr/local/include -L -loqs src/liboqs.scm
+$ gcc -fPIC -shared -I /usr/local/include \
+      src/liboqs-wrapper.c -o liboqs-wrapper.so -loqs
 ```
 
-The generated files should remain in your load path (for example the current
-directory) so the example can locate them.
+Next compile the Scheme module itself, telling `csc` to use the wrapper
+library and header:
+
+```bash
+$ csc -s -j liboqs -I src -I /usr/local/include \
+      -L -L. -L -loqs-wrapper src/liboqs.scm
+```
+
+Keep the generated files in your load path (for example the current directory)
+so the example can locate them.
 
 ## Using the wrapper
 
-Compile the example program with `csc`, telling it to use the previously
-compiled module and passing the library path via `-L` if needed:
+Compile the example program with `csc`, linking against the wrapper
+library and previously compiled module:
 
 ```bash
-$ csc -uses liboqs -I /usr/local/include -L -loqs examples/demo.scm -o demo
-$ LD_LIBRARY_PATH=/usr/local/lib ./demo
+$ csc -uses liboqs -I src -L -L. -L -loqs-wrapper \
+      examples/demo.scm -o demo
+$ LD_LIBRARY_PATH="/usr/local/lib:." ./demo
 ```
 
 To compile the module and the demo in one invocation, pass both source files
 to `csc`:
 
 ```bash
-$ csc -s -j liboqs -I /usr/local/include -L -loqs \
+$ csc -s -j liboqs -I src -I /usr/local/include -L -L. -L -loqs-wrapper \
       src/liboqs.scm -uses liboqs examples/demo.scm -o demo
 ```
 

--- a/src/liboqs-wrapper.c
+++ b/src/liboqs-wrapper.c
@@ -1,0 +1,38 @@
+#include "liboqs-wrapper.h"
+
+OQS_KEM *liboqs_kem_new(const char *name) {
+    return OQS_KEM_new(name);
+}
+
+void liboqs_kem_free(OQS_KEM *kem) {
+    OQS_KEM_free(kem);
+}
+
+size_t liboqs_kem_length_public_key(const OQS_KEM *kem) {
+    return kem->length_public_key;
+}
+
+size_t liboqs_kem_length_secret_key(const OQS_KEM *kem) {
+    return kem->length_secret_key;
+}
+
+size_t liboqs_kem_length_ciphertext(const OQS_KEM *kem) {
+    return kem->length_ciphertext;
+}
+
+size_t liboqs_kem_length_shared_secret(const OQS_KEM *kem) {
+    return kem->length_shared_secret;
+}
+
+int liboqs_kem_keypair(OQS_KEM *kem, uint8_t *pk, uint8_t *sk) {
+    return OQS_KEM_keypair(kem, pk, sk);
+}
+
+int liboqs_kem_encap(OQS_KEM *kem, uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
+    return OQS_KEM_encaps(kem, ct, ss, pk);
+}
+
+int liboqs_kem_decap(OQS_KEM *kem, uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
+    return OQS_KEM_decaps(kem, ss, ct, sk);
+}
+

--- a/src/liboqs-wrapper.h
+++ b/src/liboqs-wrapper.h
@@ -1,0 +1,16 @@
+#ifndef LIBOQS_WRAPPER_H
+#define LIBOQS_WRAPPER_H
+
+#include <oqs/oqs.h>
+
+OQS_KEM *liboqs_kem_new(const char *name);
+void liboqs_kem_free(OQS_KEM *kem);
+size_t liboqs_kem_length_public_key(const OQS_KEM *kem);
+size_t liboqs_kem_length_secret_key(const OQS_KEM *kem);
+size_t liboqs_kem_length_ciphertext(const OQS_KEM *kem);
+size_t liboqs_kem_length_shared_secret(const OQS_KEM *kem);
+int liboqs_kem_keypair(OQS_KEM *kem, uint8_t *pk, uint8_t *sk);
+int liboqs_kem_encap(OQS_KEM *kem, uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int liboqs_kem_decap(OQS_KEM *kem, uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+
+#endif /* LIBOQS_WRAPPER_H */


### PR DESCRIPTION
## Summary
- add `liboqs-wrapper.c` and header to wrap the OQS_KEM API
- use the wrapper from the Scheme module
- document updated build steps for the C wrapper

## Testing
- `gcc -fPIC -shared -I /usr/local/include src/liboqs-wrapper.c -o liboqs-wrapper.so -loqs` *(fails: `oqs/oqs.h` not found)*
- `csc -s -j liboqs -I src -I /usr/local/include -L -L. -L -loqs-wrapper src/liboqs.scm` *(fails: `csc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68538cb456f08322b25b2c52b4a22b2c