### PR TITLE
Fix foreign-lambda signature

### DIFF
--- a/src/liboqs.scm
+++ b/src/liboqs.scm
@@ -10,7 +10,7 @@
 
 
   (define kem-alg-count
-    (foreign-lambda* int ((void)) "return OQS_KEM_alg_count();"))
+    (foreign-lambda* int () "return OQS_KEM_alg_count();"))
 
   (define kem-alg-identifier
     (foreign-lambda* c-string ((size_t i)) "return OQS_KEM_alg_identifier(i);"))


### PR DESCRIPTION
## Summary
- correct the signature used to call `OQS_KEM_alg_count`

## Testing
- `gcc -fPIC -shared -I /usr/local/include src/liboqs-wrapper.c -o liboqs-wrapper.so -loqs` *(fails: `oqs/oqs.h` not found)*
- `csc -s -j liboqs -I src -I /usr/local/include -L -L. -L -loqs-wrapper src/liboqs.scm` *(fails: `csc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68538efaf954832287655485f094ad60